### PR TITLE
fixes Tristan title

### DIFF
--- a/_data/data.yml
+++ b/_data/data.yml
@@ -658,7 +658,7 @@ people:
             name: "Tristan Brigham"
             anchor: tristan_brigham
             internal: true
-            role: "Master's Student"
+            role: "Undergraduate Student"
             since: 2023
             photo: "img/people/tristan_brigham.jpg"
             interests: "Operating system security; machine learning/AI applications to systems security and exploit detection"


### PR DESCRIPTION
Tristan touched base with me last week about correcting his title. He is not YET a master's student, so I switched him to Undergraduate. This is the only change in the commit and so it can be merged.